### PR TITLE
hotfix: prevent timed out PendingWorkflow step destroying OSML

### DIFF
--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
     - uses: ahmadnassri/action-workflow-queue@v1
       with:
-        delay: 60000
-        timeout: 1800000
+        delay: 300000
+        timeout: 7200000
   BuildOSML:
     needs: CheckPendingWorkflow
     runs-on: ubuntu-latest
@@ -115,8 +115,8 @@ jobs:
       TEST_MODEL: "centerpoint"
     secrets: inherit
   DestroyOSML:
-    if: ${{ always() }}
-    needs: [ BuildOSML, RunSmallTifCenterpointTest, RunMetaNtfCenterpointTest, RunLargeTifFloodTest, RunTileNtfAircraftTest, RunTileTifAircraftTest, RunSICDCapellaChipNtfTest, RunSICDUmbraChipNtfTest, RunSICDInterferometricHhNtfTest, RunWBIDTest ]
+    if: ${{ always() && ( needs.CheckPendingWorkflow.result == 'success' )}}
+    needs: [ CheckPendingWorkflow, BuildOSML, RunSmallTifCenterpointTest, RunMetaNtfCenterpointTest, RunLargeTifFloodTest, RunTileNtfAircraftTest, RunTileTifAircraftTest, RunSICDCapellaChipNtfTest, RunSICDUmbraChipNtfTest, RunSICDInterferometricHhNtfTest, RunWBIDTest ]
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "integ:aircraft": "python3 lib/osml-model-runner-test/bin/process_image.py --image tile_tif --model aircraft",
     "integ:centerpoint": "python3 lib/osml-model-runner-test/bin/process_image.py --image small --model centerpoint",
     "integ:flood": "python3 lib/osml-model-runner-test/bin/process_image.py --image large --model flood",
+    "integ:meta": "python3 lib/osml-model-runner-test/bin/process_image.py --image meta --model centerpoint",
     "mr:docker-build": "docker build lib/osml-model-runner/. -t osml-model-runner:local",
     "mr:docker-run": "bash lib/osml-model-runner/scripts/run_container.sh",
     "mr:monitor": "bash scripts/dev_monitor.sh",


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- If multiple actions are ongoing and one of them times out, while another action is currently executing an integration test, a canceled workflow will automatically dismantle the stacks. This can potentially disrupt the progress of the other action conducting the integration test.
- Raised the timeout from 30 minutes to 120 minutes, raised check from 1 minute to 5 minutes

### Testing
- Monitor `Check` tab if it cancelling the pending workflow (first step) does not reach to `DestroyOSML` step
  - This [Action](https://github.com/aws-solutions-library-samples/guidance-for-processing-overhead-imagery-on-aws/actions/runs/8269625458) did not reach the `DestroyOSML` step. So it works! 

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
