### PR TITLE
chore (dep): update cdk-ecr-deployment to 3.0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@typescript-eslint/parser": "^5.62.0",
         "aws-cdk": "^2.104.0",
         "aws-cdk-lib": "^2.104.0",
-        "cdk-ecr-deployment": "^2.5.30",
+        "cdk-ecr-deployment": "^3.0.28",
         "cdk-nag": "^2.27.179",
         "constructs": "^10.3.0",
         "eslint": "^8.52.0",
@@ -35,7 +35,7 @@
         "eslint-plugin-simple-import-sort": "^8.0.0",
         "jest": "^29.7.0",
         "lint-staged": "^13.3.0",
-        "osml-cdk-constructs": "^1.7.1",
+        "osml-cdk-constructs": "^1.8.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.1",
         "typescript": "^5.2.2"
@@ -2976,9 +2976,9 @@
       ]
     },
     "node_modules/cdk-ecr-deployment": {
-      "version": "2.5.41",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.41.tgz",
-      "integrity": "sha512-eOnoWJ3h/PrSVjmC1QzmfK2DyvT6xBBy3ER0MeZmqTvrI+ZkOKY2ZDwNxdE2bMHmQy5XB0pAxnOVEc+FlpQSsg==",
+      "version": "3.0.42",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-3.0.42.tgz",
+      "integrity": "sha512-reQ9EGLqVttZcLsBfzX+O0mYM1YirB9Z3GDt2nIMJmM1kxxvAV4LvhfZchw4YsnycOyRDyNGpUDlhKcmyQzYEg==",
       "bundleDependencies": [
         "got",
         "hpagent"
@@ -3032,7 +3032,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/cacheable-request/node_modules/@types/node": {
-      "version": "20.10.4",
+      "version": "20.12.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3056,7 +3056,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/keyv/node_modules/@types/node": {
-      "version": "20.10.4",
+      "version": "20.12.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3074,7 +3074,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/responselike/node_modules/@types/node": {
-      "version": "20.10.4",
+      "version": "20.12.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6488,9 +6488,9 @@
       }
     },
     "node_modules/osml-cdk-constructs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/osml-cdk-constructs/-/osml-cdk-constructs-1.7.1.tgz",
-      "integrity": "sha512-M3Rhm2JKW0ceUNW69kdAB/xBxjsImO49ZR1EUJly8f7qi3s3RiS+6O09L2YudRhYbGNUgofdrCfF32Vw43ThaQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/osml-cdk-constructs/-/osml-cdk-constructs-1.8.0.tgz",
+      "integrity": "sha512-Q/pV5gHkZ5aj1LChu+GYXSge6PRJhm/oxwQOptfeKZjSnVVBDW7hgYwqs/xRWcTT21cg96a4YaDTwQbAoeKB0g==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -10135,9 +10135,9 @@
       "dev": true
     },
     "cdk-ecr-deployment": {
-      "version": "2.5.41",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.41.tgz",
-      "integrity": "sha512-eOnoWJ3h/PrSVjmC1QzmfK2DyvT6xBBy3ER0MeZmqTvrI+ZkOKY2ZDwNxdE2bMHmQy5XB0pAxnOVEc+FlpQSsg==",
+      "version": "3.0.42",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-3.0.42.tgz",
+      "integrity": "sha512-reQ9EGLqVttZcLsBfzX+O0mYM1YirB9Z3GDt2nIMJmM1kxxvAV4LvhfZchw4YsnycOyRDyNGpUDlhKcmyQzYEg==",
       "dev": true,
       "requires": {
         "aws-cdk-lib": "^2.0.0",
@@ -10171,7 +10171,7 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "20.10.4",
+              "version": "20.12.2",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -10194,7 +10194,7 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "20.10.4",
+              "version": "20.12.2",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -10212,7 +10212,7 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "20.10.4",
+              "version": "20.12.2",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12690,9 +12690,9 @@
       }
     },
     "osml-cdk-constructs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/osml-cdk-constructs/-/osml-cdk-constructs-1.7.1.tgz",
-      "integrity": "sha512-M3Rhm2JKW0ceUNW69kdAB/xBxjsImO49ZR1EUJly8f7qi3s3RiS+6O09L2YudRhYbGNUgofdrCfF32Vw43ThaQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/osml-cdk-constructs/-/osml-cdk-constructs-1.8.0.tgz",
+      "integrity": "sha512-Q/pV5gHkZ5aj1LChu+GYXSge6PRJhm/oxwQOptfeKZjSnVVBDW7hgYwqs/xRWcTT21cg96a4YaDTwQbAoeKB0g==",
       "dev": true
     },
     "p-limit": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/parser": "^5.62.0",
     "aws-cdk": "^2.104.0",
     "aws-cdk-lib": "^2.104.0",
-    "cdk-ecr-deployment": "^2.5.30",
+    "cdk-ecr-deployment": "^3.0.28",
     "cdk-nag": "^2.27.179",
     "constructs": "^10.3.0",
     "eslint": "^8.52.0",


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Update cdk-ecr-deployment to 3.0.28 due to 

```
Processing-Overhead-Imagery-on-AWS-MRContainer failed: Error: The stack named Processing-Overhead-Imagery-on-AWS-MRContainer failed creation, it may need to be manually deleted from the AWS console: ROLLBACK_COMPLETE: Resource handler returned message: "The runtime parameter of go1.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (provided.al2023) while creating or updating functions. (Service: Lambda, Status Code: 400,)" (RequestToken:, HandlerErrorCode: InvalidRequest)
```

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
