### PR TITLE
build: fix checking out the branch in submodules

### DIFF
--- a/.github/workflows/osml_update_submodules.yml
+++ b/.github/workflows/osml_update_submodules.yml
@@ -25,9 +25,10 @@ jobs:
       - name: Checkout ${{ github.ref_name }} branch for each of the submodules
         run: |
           git submodule update --init --recursive --remote lib/${{ inputs.DISPATCH_REPO_NAME }}
-          git submodule set-branch --branch ${{ github.ref_name }} lib/${{ inputs.DISPATCH_REPO_NAME }}
+          git submodule set-branch --branch main lib/${{ inputs.DISPATCH_REPO_NAME }}
           cd lib/${{ inputs.DISPATCH_REPO_NAME }}
-          git checkout ${{ github.ref_name }}
+          git checkout main
+          git pull --rebase
           cd ../../
           git checkout .gitmodules
       - name: Run Git Status

--- a/.github/workflows/osml_update_submodules.yml
+++ b/.github/workflows/osml_update_submodules.yml
@@ -27,8 +27,7 @@ jobs:
           git submodule update --init --recursive --remote lib/${{ inputs.DISPATCH_REPO_NAME }}
           git submodule set-branch --branch main lib/${{ inputs.DISPATCH_REPO_NAME }}
           cd lib/${{ inputs.DISPATCH_REPO_NAME }}
-          git checkout main
-          git pull --rebase
+          git checkout ${{inputs.DISPATCH_REPO_SHA}}
           cd ../../
           git checkout .gitmodules
       - name: Run Git Status


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Fix an issue with the submodule workflow such that we are pulling from the commit id rather than the branch to ensure we are pulling the latest changes.

### Testing


Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
