### PR TITLE
buid: update credential timeout for destroy steps

### DIFF
--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -125,7 +125,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          role-duration-seconds: 7200
+          role-duration-seconds: 14400
       - name: Destroy OSML stack(s)
         uses: aws-actions/aws-codebuild-run-build@v1
         with:


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Update the timeout from 2 hours to 4 hours as a temporary fix until we have this feature in: https://github.com/aws/aws-cdk/issues/22424

### Testing
- Check `Check` tab

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
