### PR TITLE
fix: import

### DIFF
--- a/bin/deploy-tile-server.ts
+++ b/bin/deploy-tile-server.ts
@@ -3,14 +3,13 @@
  */
 
 import { App, Environment } from "aws-cdk-lib";
-import { OSMLAccount } from "osml-cdk-constructs";
+import { OSMLAccount, OSMLAuthConfig } from "osml-cdk-constructs";
 
 import { OSMLVpcStack } from "../lib/osml-stacks/osml-vpc";
 import { TSImageryStack } from "../lib/osml-stacks/tile_server/testing/ts-imagery";
 import { TSTestRunnerStack } from "../lib/osml-stacks/tile_server/testing/ts-test-runner";
 import { TSContainerStack } from "../lib/osml-stacks/tile_server/ts-container";
 import { TSDataplaneStack } from "../lib/osml-stacks/tile_server/ts-dataplane";
-import { OSMLAuthConfig } from "../lib/osml-cdk-constructs/lib/osml/osml_authenticate";
 
 /**
  * Initializes and deploys the infrastructure required for operating a tile server.

--- a/lib/osml-stacks/tile_server/ts-dataplane.ts
+++ b/lib/osml-stacks/tile_server/ts-dataplane.ts
@@ -5,8 +5,12 @@
 import { App, Environment, Stack, StackProps } from "aws-cdk-lib";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 import { IRole } from "aws-cdk-lib/aws-iam";
-import { OSMLAccount, OSMLVpc, TSDataplane } from "osml-cdk-constructs";
-import { OSMLAuthConfig } from "../../osml-cdk-constructs/lib/osml/osml_authenticate";
+import {
+  OSMLAccount,
+  OSMLAuthConfig,
+  OSMLVpc,
+  TSDataplane
+} from "osml-cdk-constructs";
 
 export interface TSDataplaneStackProps extends StackProps {
   readonly env: Environment;


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Fixing import of OSMLAuthConfig to import from library instead of local path.

### Testing


Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
