### PR TITLE
chore: migrate submodules .git to https

### DIFF
--- a/.github/codebuild/build.yml
+++ b/.github/codebuild/build.yml
@@ -5,7 +5,6 @@ phases:
       nodejs: 16
   pre_build:
     commands:
-      - sed -i "s/git@github.com:/https:\/\/github.com\//" .gitmodules
       - git submodule update --init --recursive
       - |
         if [[ "$BASE_REF" == "dev" ]]; then

--- a/.github/codebuild/cdk-nag.yml
+++ b/.github/codebuild/cdk-nag.yml
@@ -5,7 +5,6 @@ phases:
       nodejs: 18
   pre_build:
     commands:
-      - sed -i "s/git@github.com:/https:\/\/github.com\//" .gitmodules
       - git submodule update --init --recursive
       - |
         if [[ "${BASE_REF}" -eq "dev" ]]; then

--- a/.github/codebuild/destroy.yml
+++ b/.github/codebuild/destroy.yml
@@ -2,7 +2,6 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - sed -i "s/git@github.com:/https:\/\/github.com\//" .gitmodules
       - git submodule update --init --recursive
       - |
         if [[ "$BASE_REF" == "dev" ]]; then

--- a/.github/codebuild/test.yml
+++ b/.github/codebuild/test.yml
@@ -2,7 +2,6 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - sed -i "s/git@github.com:/https:\/\/github.com\//" .gitmodules
       - git submodule update --init --recursive
       - python3 -m pip install lib/osml-model-runner-test/
   build:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,21 @@
 [submodule "lib/osml-model-runner"]
 	path = lib/osml-model-runner
-	url = git@github.com:aws-solutions-library-samples/osml-model-runner.git
+	url = https://github.com/aws-solutions-library-samples/osml-model-runner.git
 [submodule "lib/osml-models"]
 	path = lib/osml-models
-	url = git@github.com:aws-solutions-library-samples/osml-models.git
+	url = https://github.com/aws-solutions-library-samples/osml-models.git
 [submodule "lib/osml-model-runner-test"]
 	path = lib/osml-model-runner-test
-	url = git@github.com:aws-solutions-library-samples/osml-model-runner-test.git
+	url = https://github.com/aws-solutions-library-samples/osml-model-runner-test.git
 [submodule "lib/osml-cdk-constructs"]
 	path = lib/osml-cdk-constructs
-	url = git@github.com:aws-solutions-library-samples/osml-cdk-constructs.git
-[submodule "lib/guidance-for-overhead-imagery-inference-on-aws"]
-	path = lib/guidance-for-overhead-imagery-inference-on-aws
-	url = git@github.com:aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws.git
+	url = https://github.com/aws-solutions-library-samples/osml-cdk-constructs.git
 [submodule "lib/osml-cesium-globe"]
 	path = lib/osml-cesium-globe
-	url = git@github.com:aws-solutions-library-samples/osml-cesium-globe.git
+	url = https://github.com/aws-solutions-library-samples/osml-cesium-globe.git
 [submodule "lib/osml-tile-server"]
 	path = lib/osml-tile-server
-	url = git@github.com:aws-solutions-library-samples/osml-tile-server.git
+	url = https://github.com/aws-solutions-library-samples/osml-tile-server.git
 [submodule "lib/osml-tile-server-test"]
 	path = lib/osml-tile-server-test
 	url = https://github.com/aws-solutions-library-samples/osml-tile-server-test.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The branches developers should create directly off of `dev` (our trunk) as part 
 #### Step 1: Clone the Repository
 Clone the repository to your local machine.
 ```bash
-git clone git@github.com:aws-solutions-library-samples/guidance-for-processing-overhead-imagery-on-aws.git
+git clone https://github.com/aws-solutions-library-samples/guidance-for-processing-overhead-imagery-on-aws.git
 ```
 
 #### Step 2: Create a New Branch

--- a/scripts/ec2_bootstrap_al2.sh
+++ b/scripts/ec2_bootstrap_al2.sh
@@ -74,7 +74,6 @@ chmod -R 777 $OSML_REPO
 
 # Clone submodules from HTTPS instead of SSH (since git ssh keys are not available yet)
 cd $OSML_REPO \
-    && sed -i 's/git@github.com:/https:\/\/github.com\//g' .gitmodules \
     && git submodule update --init --recursive
 
 echo "--------------------- EC2 Bootstrap complete ---------------------"

--- a/scripts/ec2_bootstrap_ubuntu.sh
+++ b/scripts/ec2_bootstrap_ubuntu.sh
@@ -79,7 +79,6 @@ chmod -R 777 $OSML_REPO
 
 # Clone submodules from HTTPS instead of SSH (since git ssh keys are not available yet)
 cd $OSML_REPO \
-    && sed -i 's/git@github.com:/https:\/\/github.com\//g' .gitmodules \
     && git submodule update --init --recursive
 
 echo "--------------------- EC2 Bootstrap complete ---------------------"


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Shift `.gitmodules` from `git@` to `https:`

### Testing
- Check `Checks` tab

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
