### PR TITLE
chore: bump up osml-cdk-constructs to 1.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "jest": "^29.7.0",
         "lint-staged": "^15.2.2",
-        "osml-cdk-constructs": "1.13.0",
+        "osml-cdk-constructs": "1.13.2",
         "prettier": "^3.3.2",
         "ts-jest": "^29.1.5",
         "typescript": "^5.4.5"
@@ -200,47 +200,47 @@
       }
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.614.0.tgz",
-      "integrity": "sha512-8wN1Run21UELmYWzg9N0w9hxh9YtwUsbbXEOwoJ4INMGzfXk8uZagEwoWd9zzCrkP7MnBIF3oPsiOw1pPZ9iPA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.620.0.tgz",
+      "integrity": "sha512-8cq7qIwiePA4AqaLgLubxwdem30GlnOSmDIP+8H58w8MRTVehbsehdBsbY27mEIbPwinrsyOzKU94qxSPyWxIA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.614.0",
-        "@aws-sdk/client-sts": "3.614.0",
-        "@aws-sdk/core": "3.614.0",
-        "@aws-sdk/credential-provider-node": "3.614.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.620.0",
+        "@aws-sdk/client-sts": "3.620.0",
+        "@aws-sdk/core": "3.620.0",
+        "@aws-sdk/credential-provider-node": "3.620.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.6",
-        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.9",
-        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -253,44 +253,44 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.614.0.tgz",
-      "integrity": "sha512-p5pyYaxRzBttjBkqfc8i3K7DzBdTg3ECdVgBo6INIUxfvDy0J8QUE8vNtCgvFIkq+uPw/8M+Eo4zzln7anuO0Q==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.620.0.tgz",
+      "integrity": "sha512-J1CvF7u39XwtCK9rPlkW2AA631EPqkb4PjOOj9aZ9LjQmkJ0DkL+9tEqU2XIWcjDd2Z3hS3LBuS8uN7upIkEnQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.614.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.620.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.6",
-        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.9",
-        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -302,45 +302,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.614.0.tgz",
-      "integrity": "sha512-BI1NWcpppbHg/28zbUg54dZeckork8BItZIcjls12vxasy+p3iEzrJVG60jcbUTTsk3Qc1tyxNfrdcVqx0y7Ww==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.620.0.tgz",
+      "integrity": "sha512-CWL8aJa6rrNaQXNsLhblGZzbFBrRz4BXAsFBbyqAZEmryr9q/IC7z/ww3nq8CD2UsW+bn89U/XcoP5r1KWUHuQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.614.0",
-        "@aws-sdk/credential-provider-node": "3.614.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.620.0",
+        "@aws-sdk/credential-provider-node": "3.620.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.6",
-        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.9",
-        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -351,50 +351,50 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.614.0"
+        "@aws-sdk/client-sts": "^3.620.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.614.0.tgz",
-      "integrity": "sha512-i6QmaVA1KHHYNnI2VYQy/sc31rLm4+jSp8b/YbQpFnD0w3aXsrEEHHlxek45uSkHb4Nrj1omFBVy/xp1WVYx2Q==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.620.0.tgz",
+      "integrity": "sha512-pG4SqDHZV/ZbpoVoVtpxo6ZZoqVDbVItC3QUO73UJ3Gemxznd/Ck7kAsyb6/dJkV/Aqm3gt2O5UL7vzQLNHSjw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.614.0",
-        "@aws-sdk/core": "3.614.0",
-        "@aws-sdk/credential-provider-node": "3.614.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.620.0",
+        "@aws-sdk/core": "3.620.0",
+        "@aws-sdk/credential-provider-node": "3.620.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.6",
-        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.9",
-        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -406,15 +406,15 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.614.0.tgz",
-      "integrity": "sha512-BUuS5/1YkgmKc4J0bg83XEtMyDHVyqG2QDzfmhYe8gbOIZabUl1FlrFVwhCAthtrrI6MPGTQcERB4BtJKUSplw==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.620.0.tgz",
+      "integrity": "sha512-5D9tMahxIDDFLULS9/ULa0HuIu7CZSshfj6wmDSmigXzkWyUvHoVIrme2z6eM3Icat/MO3d4WEy3445Vk385gQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/core": "^2.2.6",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/core": "^2.3.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.6.2"
@@ -439,19 +439,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.614.0.tgz",
-      "integrity": "sha512-YIEjlNUKb3Vo/iTnGAPdsiDC3FUUnNoex2OwU8LmR7AkYZiWdB8nx99DfgkkY+OFMUpw7nKD2PCOtuFONelfGA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.620.0.tgz",
+      "integrity": "sha512-BI2BdrSKDmB/2ouB/NJR0PT0x/+5fmoF6XOE78hFBb4F5w/yynGgcJY936dF+oREfpME6ehjB2b0okGg78Scpw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.1",
-        "@smithy/node-http-handler": "^3.1.2",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.6",
+        "@smithy/util-stream": "^3.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -459,18 +459,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.614.0.tgz",
-      "integrity": "sha512-KfLuLFGwlvFSZ2MuzYwWGPb1y5TeiwX5okIDe0aQ1h10oD3924FXbN+mabOnUHQ8EFcGAtCaWbrC86mI7ktC6A==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.620.0.tgz",
+      "integrity": "sha512-P9fYi6dzZIl8ITC7qAPf5DX9omI3LfA91g3KH+0OUmS3ctP7tN+gNo3HmqlzoqnwPe0pXn1FumYAe1qFl6Yjjg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.614.0",
+        "@aws-sdk/credential-provider-http": "3.620.0",
         "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.620.0",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -480,23 +480,23 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.614.0"
+        "@aws-sdk/client-sts": "^3.620.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.614.0.tgz",
-      "integrity": "sha512-4J6gPEuFZP0mkWq5E//oMS1vrmMM88iNNcv7TEljYnsc6JTAlKejCyFwx6CN+nkIhmIZsl06SXIhBemzBdBPfg==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.620.0.tgz",
+      "integrity": "sha512-or8ahy4ysURcWgKX00367DMDTTyMynDEl+FQh4wce66fMyePhFVuoPcRgXzWsi8KYmL95sPCfJFNqBMyFNcgvQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.614.0",
-        "@aws-sdk/credential-provider-ini": "3.614.0",
+        "@aws-sdk/credential-provider-http": "3.620.0",
+        "@aws-sdk/credential-provider-ini": "3.620.0",
         "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.620.0",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -523,12 +523,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.614.0.tgz",
-      "integrity": "sha512-55+gp0JY4451cWI1qXmVMFM0GQaBKiQpXv2P0xmd9P3qLDyeFUSEW8XPh0d2lb1ICr6x4s47ynXVdGCIv2mXMg==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.620.0.tgz",
+      "integrity": "sha512-xtIj2hmq3jcKwvGmqhoYapbWeQfFyoQgKBtwD6nx0M6oS5lbFH4rzHhj0gBwatZDjMa35cWtcYVUJCv2/9mWvA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.614.0",
+        "@aws-sdk/client-sso": "3.620.0",
         "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -559,13 +559,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-      "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -588,13 +588,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-      "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -603,14 +603,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.614.0.tgz",
-      "integrity": "sha512-xUxh0UPQiMTG6E31Yvu6zVYlikrIcFDKljM11CaatInzvZubGTGiX0DjpqRlfGzUNsuPc/zNrKwRP2+wypgqIw==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
+      "integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
-      "integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.0.tgz",
+      "integrity": "sha512-P4fwKI2mjEb3ZU5cnMJzvRsRKGBUcs8jvxIoRmr6ufAY9Xk2Bz7JubRTTivkw55c7WQJfTECeqYVa+HZ0FzREg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -791,12 +791,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
-      "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
+      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.24.9",
+        "@babel/types": "^7.25.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -830,43 +830,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
@@ -881,16 +844,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
-      "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.0.tgz",
+      "integrity": "sha512-bIkOa2ZJYn7FHnepzr5iX9Kmz8FjIz4UKzJ9zhX3dnYuVW0xul9RuR3skBfoLu+FPTQw90EHW9rJsSZhyLQ3fQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-module-imports": "^7.24.7",
         "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7"
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/traverse": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -915,18 +877,6 @@
       "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-      "dev": true,
-      "dependencies": {
         "@babel/types": "^7.24.7"
       },
       "engines": {
@@ -961,13 +911,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
-      "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.8"
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1060,9 +1010,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
-      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.0.tgz",
+      "integrity": "sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1249,33 +1199,30 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/parser": "^7.25.0",
+        "@babel/types": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
-      "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.0.tgz",
+      "integrity": "sha512-ubALThHQy4GCf6mbb+5ZRNmLLCI7bJ3f8Q6LHBSRlSKSWj5a7dSUzJBLv3VuIhFrFPgjF4IzPF567YG/HSCdZA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.8",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-hoist-variables": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.8",
-        "@babel/types": "^7.24.8",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1293,9 +1240,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
-      "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.0.tgz",
+      "integrity": "sha512-LcnxQSsd9aXOIgmmSpvZ/1yo46ra2ESYyqLcryaBZOghxy5qqOBjvCWP5JfkI8yl9rlxRgdLTTMCQQRcN2hdCg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",
@@ -2492,16 +2439,16 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.7.tgz",
-      "integrity": "sha512-Wwd9QWKaYdR+n/oIqJbuwSr9lHuv7sa1e3Zu4wIToZl0sS7xapTYYqQtXP1hKKtIWz0jl8AhvOfNwkfT5jjV0w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-tvSwf+PF5uurExeJsl+sSNn4bPsYShL86fJ/wcj63cioJ0IF131BxC5QxX8qkIISk7Pr7g2+UJH9ib4cCafvqw==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
@@ -2511,9 +2458,9 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
-      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
       "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
@@ -2527,12 +2474,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
-      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.3.tgz",
+      "integrity": "sha512-m4dzQeafWi5KKCCnDwGGHYk9lqcLs9LvlXZRB0J38DMectsEbxdiO/Rx1NaYYMIkath7AnjpR+r0clL+7dwclQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
@@ -2577,12 +2524,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
-      "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
       "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2591,9 +2538,9 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dev": true,
       "dependencies": {
         "@smithy/middleware-serde": "^3.0.3",
@@ -2609,15 +2556,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.10.tgz",
-      "integrity": "sha512-+6ibpv6jpkTNJS6yErQSEjbxCWf1/jMeUSlpSlUiTYf73LGR9riSRlIrL1+JEW0eEpb6MelQ04BIc38aj8GtxQ==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.12.tgz",
+      "integrity": "sha512-CncrlzNiBzuZZYLJ49H4dC6FEz62hnv0Y0nJyl/oZ73FX/9CDHWkIRD4ZOf5ntB6QyYWx0G3mXAOHOcM5omlLg==",
       "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -2670,13 +2617,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
-      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
       "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -2699,9 +2646,9 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
-      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dev": true,
       "dependencies": {
         "@smithy/types": "^3.3.0",
@@ -2764,12 +2711,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
-      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -2782,16 +2730,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.8.tgz",
-      "integrity": "sha512-nUNGCa0NgvtD0eM45732EBp1H9JQITChMBegGtPRhJD00v3hiFF6tibiOihcYwP5mbp9Kui+sOCl86rDT/Ew2w==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.10.tgz",
+      "integrity": "sha512-OLHJo0DAmhX69YUF3WbNfzzxGIncGdxao+v27o24msdhin2AWTxJMaBQ3iPGfIrWMjy+8YGMXUJ7PrkJlpznTw==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.0",
+        "@smithy/util-stream": "^3.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2882,13 +2830,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.10.tgz",
-      "integrity": "sha512-WgaNxh33md2zvlD+1TSceVmM7DIy7qYMtuhOat+HYoTntsg0QTbNvoB/5DRxEwSpN84zKf9O34yqzRRtxJZgFg==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.12.tgz",
+      "integrity": "sha512-5b81UUPKjD61DMg7JBYzkSM1Vny/RfRRhnZYzuWjm25OyrEXsar3RgbbXYR+otdx+wrPR3QmuFtbDZmEgGpwVg==",
       "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -2898,16 +2846,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.10.tgz",
-      "integrity": "sha512-3x/pcNIFyaAEQqXc3qnQsCFLlTz/Mwsfl9ciEPU56/Dk/g1kTFjkzyLbUNJaeOo5HT01VrpJBKrBuN94qbPm9A==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.12.tgz",
+      "integrity": "sha512-g2NdtGDN67PepBs0t/mkrlQ2nVkhKUDJZCNmEJIarzYq2sK4mKO9t61Nzlv+gHEEC3ESfRaMCC/Ol3ZfCZYg7Q==",
       "dev": true,
       "dependencies": {
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2969,13 +2917,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.0.tgz",
-      "integrity": "sha512-QEMvyv58QIptWA8cpQPbHagJOAlrbCt3ueB9EShwdFfVMYAviXdVtksszQQq+o+dv5dalUMWUbUHUDSJgkF9xg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.2.tgz",
+      "integrity": "sha512-08zDzB7BqvybHfZKnav5lL1UniFDK6o6nZ3OWp60PKsi/na2LpU6OX8MCtDNVaPBpKpc8EH26fvFhNT6wvMlbw==",
       "dev": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
@@ -3137,9 +3085,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "20.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3175,16 +3123,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.16.1.tgz",
-      "integrity": "sha512-SxdPak/5bO0EnGktV05+Hq8oatjAYVY3Zh2bye9pGZy6+jwyR3LG3YKkV4YatlsgqXP28BTeVm9pqwJM96vf2A==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.17.0.tgz",
+      "integrity": "sha512-pyiDhEuLM3PuANxH7uNYan1AaFs5XE0zw1hq69JBvGvE7gSuEoQl1ydtEe/XQeoC3GQxLXyOVa5kNOATgM638A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.16.1",
-        "@typescript-eslint/type-utils": "7.16.1",
-        "@typescript-eslint/utils": "7.16.1",
-        "@typescript-eslint/visitor-keys": "7.16.1",
+        "@typescript-eslint/scope-manager": "7.17.0",
+        "@typescript-eslint/type-utils": "7.17.0",
+        "@typescript-eslint/utils": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3208,15 +3156,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.16.1.tgz",
-      "integrity": "sha512-u+1Qx86jfGQ5i4JjK33/FnawZRpsLxRnKzGE6EABZ40KxVT/vWsiZFEBBHjFOljmmV3MBYOHEKi0Jm9hbAOClA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.17.0.tgz",
+      "integrity": "sha512-puiYfGeg5Ydop8eusb/Hy1k7QmOU6X3nvsqCgzrB2K4qMavK//21+PzNE8qeECgNOIoertJPUC1SpegHDI515A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.16.1",
-        "@typescript-eslint/types": "7.16.1",
-        "@typescript-eslint/typescript-estree": "7.16.1",
-        "@typescript-eslint/visitor-keys": "7.16.1",
+        "@typescript-eslint/scope-manager": "7.17.0",
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/typescript-estree": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3236,13 +3184,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.1.tgz",
-      "integrity": "sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.17.0.tgz",
+      "integrity": "sha512-0P2jTTqyxWp9HiKLu/Vemr2Rg1Xb5B7uHItdVZ6iAenXmPo4SZ86yOPCJwMqpCyaMiEHTNqizHfsbmCFT1x9SA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.1",
-        "@typescript-eslint/visitor-keys": "7.16.1"
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -3253,13 +3201,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.16.1.tgz",
-      "integrity": "sha512-rbu/H2MWXN4SkjIIyWcmYBjlp55VT+1G3duFOIukTNFxr9PI35pLc2ydwAfejCEitCv4uztA07q0QWanOHC7dA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.17.0.tgz",
+      "integrity": "sha512-XD3aaBt+orgkM/7Cei0XNEm1vwUxQ958AOLALzPlbPqb8C1G8PZK85tND7Jpe69Wualri81PLU+Zc48GVKIMMA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.16.1",
-        "@typescript-eslint/utils": "7.16.1",
+        "@typescript-eslint/typescript-estree": "7.17.0",
+        "@typescript-eslint/utils": "7.17.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3280,9 +3228,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.1.tgz",
-      "integrity": "sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-a29Ir0EbyKTKHnZWbNsrc/gqfIBqYPwj3F2M+jWE/9bqfEHg0AMtXzkbUkOG6QgEScxh2+Pz9OXe11jHDnHR7A==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -3293,13 +3241,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.1.tgz",
-      "integrity": "sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.17.0.tgz",
+      "integrity": "sha512-72I3TGq93t2GoSBWI093wmKo0n6/b7O4j9o8U+f65TVD0FS6bI2180X5eGEr8MA8PhKMvYe9myZJquUT2JkCZw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.1",
-        "@typescript-eslint/visitor-keys": "7.16.1",
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3321,15 +3269,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.16.1.tgz",
-      "integrity": "sha512-WrFM8nzCowV0he0RlkotGDujx78xudsxnGMBHI88l5J8wEhED6yBwaSLP99ygfrzAjsQvcYQ94quDwI0d7E1fA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.17.0.tgz",
+      "integrity": "sha512-r+JFlm5NdB+JXc7aWWZ3fKSm1gn0pkswEwIYsrGPdsT2GjsRATAKXiNtp3vgAAO1xZhX8alIOEQnNMl3kbTgJw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.16.1",
-        "@typescript-eslint/types": "7.16.1",
-        "@typescript-eslint/typescript-estree": "7.16.1"
+        "@typescript-eslint/scope-manager": "7.17.0",
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/typescript-estree": "7.17.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -3343,12 +3291,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.1.tgz",
-      "integrity": "sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.17.0.tgz",
+      "integrity": "sha512-RVGC9UhPOCsfCdI9pU++K4nD7to+jTcMIbXTSOcrLqUEW6gF2pU1UUbYJKc9cvcRSK1UDeMJ7pdMxf4bhMpV/A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/types": "7.17.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -3632,9 +3580,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.149.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.149.0.tgz",
-      "integrity": "sha512-X+FGIJuBbsFPwA5tM4uOh9qdK1pbPZ6WK1QbtVfN7YsruwEgdx12wB8H3oLh3waFS87/rCww05Z1PzDdM+edCg==",
+      "version": "2.150.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.150.0.tgz",
+      "integrity": "sha512-leo4J70QrJp+SYm/87VuoOVfALsW11F7JpkAGu5TLL/qd2k/CbovZ8k9/3Ov+jCVsvAgdn9DeHL01Sn6hSl6Zg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -3647,9 +3595,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.149.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.149.0.tgz",
-      "integrity": "sha512-bmbgnF2dEYlsZlVaNoSfcjyIUirnvmsvNXJwBMmUCZn2IZ+YWvkMv+rr4e/GO3gPKrdNzew1jNVvHSYxlun6rA==",
+      "version": "2.150.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.150.0.tgz",
+      "integrity": "sha512-A5dJ6iIAXlkSgUIKhhSd5slEjvDBiREv6/xw8CgrXU+puoFULu5bC0SOQARjTzcsAgAVtxdlaZ7qy7u9It7nHQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -4269,9 +4217,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001642",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
-      "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
+      "version": "1.0.30001643",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
       "dev": true,
       "funding": [
         {
@@ -4289,9 +4237,9 @@
       ]
     },
     "node_modules/cdk-ecr-deployment": {
-      "version": "3.0.75",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-3.0.75.tgz",
-      "integrity": "sha512-8HRgyW/jaGF2AnpKuTC3xbvfcxJO5ILzf74nVkGioa2XIki/COBSnUtCwaTC9QOYRFaKjX7jmFqo2Onv8sI2Cw==",
+      "version": "3.0.76",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-3.0.76.tgz",
+      "integrity": "sha512-a8Szp0Non2WfNVZJmSxs/UuekoZgrA4BNkxje18AUAj+9/cPkArZBvIcGXfkBB83cQV/J+pjrEVRsboW8Dv9rA==",
       "bundleDependencies": [
         "got",
         "hpagent"
@@ -4345,7 +4293,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/cacheable-request/node_modules/@types/node": {
-      "version": "20.14.10",
+      "version": "20.14.12",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4369,7 +4317,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/keyv/node_modules/@types/node": {
-      "version": "20.14.10",
+      "version": "20.14.12",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4387,7 +4335,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/responselike/node_modules/@types/node": {
-      "version": "20.14.10",
+      "version": "20.14.12",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4660,9 +4608,9 @@
       "license": "ISC"
     },
     "node_modules/cdk-nag": {
-      "version": "2.28.160",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.160.tgz",
-      "integrity": "sha512-Bwx33izyzeraHf+qbVFnFgcayRIDN3DwXTXIrNrgiS4idUGqKtcM2QJtpvsoLkma411mwYoPmhT1cRu1YFxJAA==",
+      "version": "2.28.165",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.165.tgz",
+      "integrity": "sha512-kvfiUXJYLJRb1JQhpIdE7m6Vk8KK76UArp+VvBRvbgET0okbZBjVKh9u1BfJ6QUyEzt5lIcJK/lhZiNg2ngxuw==",
       "dev": true,
       "peerDependencies": {
         "aws-cdk-lib": "^2.116.0",
@@ -4716,15 +4664,15 @@
       "dev": true
     },
     "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "dependencies": {
-        "restore-cursor": "^4.0.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5113,9 +5061,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.828",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
-      "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.2.tgz",
+      "integrity": "sha512-kc4r3U3V3WLaaZqThjYz/Y6z8tJe+7K0bbjUVo3i+LWIypVdMx5nXCkwRe6SWbY6ILqLdc1rKcKmr3HoH7wjSQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5137,9 +5085,9 @@
       "dev": true
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -5147,6 +5095,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -5559,13 +5519,13 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
-      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+      "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.6"
+        "synckit": "^0.9.1"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -5589,9 +5549,9 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.4.0.tgz",
-      "integrity": "sha512-/KWWRaD3fGkVCZsdR0RU53PSthFmoHVhZl+y9+6DqeDLSikLdlUVpVEAmI6iCRR5QyOjBYBqHZV/bdv4DJ4Gtw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
+      "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6114,9 +6074,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
-      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.6.tgz",
+      "integrity": "sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6377,9 +6337,9 @@
       }
     },
     "node_modules/import-local": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -6498,9 +6458,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
-      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
       "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6808,9 +6768,9 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.1.tgz",
-      "integrity": "sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.3",
@@ -7744,14 +7704,14 @@
       "dev": true
     },
     "node_modules/log-update": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
-      "integrity": "sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^6.2.0",
-        "cli-cursor": "^4.0.0",
-        "slice-ansi": "^7.0.0",
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
         "strip-ansi": "^7.1.0",
         "wrap-ansi": "^9.0.0"
       },
@@ -7763,12 +7723,15 @@
       }
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
-      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
       "dev": true,
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7919,6 +7882,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -7962,9 +7937,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -8118,9 +8093,9 @@
       }
     },
     "node_modules/osml-cdk-constructs": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/osml-cdk-constructs/-/osml-cdk-constructs-1.13.0.tgz",
-      "integrity": "sha512-6EFpfVIUM4iXSHIU24EL/1AnC7tUHwMNHlupur0CRHdvlktoP95jTTLrq72A53hYNApBAv9WgJM+8eywq0cFAg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/osml-cdk-constructs/-/osml-cdk-constructs-1.13.2.tgz",
+      "integrity": "sha512-VJ0oSUxnm8/cjcOd9LT6TANaTOG4KU8a+qiJ56J7fdZfBzjyMBaVgbREHsRYhSF0bUZGMIUh6wCOKyJNJWbsrw==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -8565,19 +8540,46 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/reusify": {
@@ -8671,9 +8673,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -9036,9 +9038,9 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
-      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+      "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
       "dev": true,
       "dependencies": {
         "@pkgr/core": "^0.1.0",
@@ -9142,13 +9144,13 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.2.tgz",
-      "integrity": "sha512-sSW7OooaKT34AAngP6k1VS669a0HdLxkQZnlC7T76sckGCokXFnvJ3yRlQZGRTAoV5K19HfSgCiSwWOSIfcYlg==",
+      "version": "29.2.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.3.tgz",
+      "integrity": "sha512-yCcfVdiBFngVz9/keHin9EnsrQtQtEu3nRykNy9RVp+FiPFFbPJ3Sg6Qg4+TkmH0vMP5qsTKgXSsk80HRwvdgQ==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
-        "ejs": "^3.0.0",
+        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^29.0.0",
         "json5": "^2.2.3",
@@ -9377,9 +9379,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "jest": "^29.7.0",
     "lint-staged": "^15.2.2",
-    "osml-cdk-constructs": "1.13.0",
+    "osml-cdk-constructs": "1.13.2",
     "prettier": "^3.3.2",
     "ts-jest": "^29.1.5",
     "typescript": "^5.4.5"


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Bump up `osml-cdk-constructs` to 1.13.2

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
