### PR TITLE
fix:ts integ test output display

### DIFF
--- a/scripts/tile_server_integ.sh
+++ b/scripts/tile_server_integ.sh
@@ -89,16 +89,16 @@ log_result=$(aws lambda invoke --region "$AWS_REGION" \
                                --query 'LogResult' \
                                --output text | base64 --decode)
 
+echo "$log_result" | sed -n '/^Test Summary/,/Success: [0-9]\+\.[0-9]\+%/p'
+
 # Clean up the temporary payload file
 rm tmp_payload.json
 
 # Decode the log result and check for success
 if echo "$log_result" | grep -q "Success: 100.00%"; then
-    echo "$log_result" | sed -n '/^Test Summary/,/Success: [0-9]\+\.[0-9]\+%/p'
     print_test_passed
     exit 0
 else
-    echo "$log_result" | sed -n '/^{.*"message":/p' | jq -r '.message' | sed 's/\\n/\n/g'
     print_test_failed
     exit 1
 fi


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Fixes a minor bug in how tile server integration test output is displayed.

### Testing


Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
