### PR TITLE
build: speed up destroy step in CI/CD

### DIFF
--- a/scripts/dev_destroy.sh
+++ b/scripts/dev_destroy.sh
@@ -36,6 +36,16 @@ destroy_minimal_stacks() {
     local STACK_LIST=".*TileServer.*|.*Test-ModelEndpoints.*|.*ModelRunner.*|.*DataIntake.*|.*DataCatalog.*"
     cdk list | sort -r | grep -E "$STACK_LIST" > stack_list.txt
 
+    # This is to speed up the AWS CloudFormation delete-stack
+    # so we can start deleting all stacks at once
+    echo "Performing AWS CloudFormation delete-stack for matching stacks..."
+    for stack_name in $(cat stack_list.txt); do
+        if [[ "$stack_name" =~ $STACK_LIST ]]; then
+            echo "Deleting CloudFormation stack $stack_name..."
+            aws cloudformation delete-stack --stack-name "$stack_name"
+        fi
+    done
+
     for stack_name in $(cat stack_list.txt); do
         echo "Destroying stack $stack_name..."
         cdk destroy "$stack_name" --force


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Speed up the destroy step in Github workflow action. Currently, it takes about 1 hr 30 minutes to destroy the resources which is a long time. Reduced from 1.5 hr to 1hr. 

### Testing
- Check `Checks` tab

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
